### PR TITLE
Update dashboards.rst

### DIFF
--- a/docs/user/dashboards.rst
+++ b/docs/user/dashboards.rst
@@ -4,9 +4,7 @@
 Dashboards
 **********
 
-Dashboards allow configuring widgets and what alerts to show.
-
-Dasboards have the following fields:
+ZMON's customizable dashboards enable you to configure widgets and choose which alerts to show. Dashboards have the following fields:
 
     name
         The dashboard's name. This is mainly used to identify the dashboard.


### PR DESCRIPTION
Just made a few tiny fixes near the top, then stopped after thinking that this page could be reorganized as these sections: 
Dashboard Fields
Widget Configuration
- Supported Widget Types
  - gauge
  - chart
  - value
  - networkmap
  - iframe
- "Widgets styling and effects based on active alerts" 

Note that here -- https://github.com/zalando/zmon-docs/blob/master/docs/user/dashboards.rst#value-gauge-chart-trend:
-  "Trend" is listed, but not described
- "gauge" is referred to near the bottom ("On the sample below the gauge widget") but there is no sample
- chart is described in detail (let's add a subsection for it)
- networkmap has its own section/OK; 
- iFrame also has its own section but is not listed here (https://github.com/zalando/zmon-docs/blob/master/docs/user/dashboards.rst#value-gauge-chart-trend). 

Alert Age is listed as a widget; is it a widget?

LMK if this order makes sense. Rearranging could tighten up the whole page; it should at least make it easier to find and standardize the info provided. :)
