### PR TITLE
Update docs to include start_absolute and end_absolute params on kairosdb query

### DIFF
--- a/docs/user/check-ref/kairosdb_wrapper.rst
+++ b/docs/user/check-ref/kairosdb_wrapper.rst
@@ -12,7 +12,7 @@ Provides read access to the target KairosDB
 Methods of KairosDB
 ^^^^^^^^^^^^^^^^^^^
 
-.. py:function:: query(name, group_by = None, tags = None, start = -5, end = 0, time_unit='seconds', aggregators = None)
+.. py:function:: query(name, group_by = None, tags = None, start = -5, end = 0, time_unit='seconds', aggregators = None, start_absolute = None, end_absolute = None)
 
     ::
 
@@ -38,6 +38,12 @@ Methods of KairosDB
 
     :param aggregators: List of aggregators.
     :type aggregators: list
+
+    :param start_absolute: Absolute start time in milliseconds, overrides the start parameter which is relative
+    :type start_absolute: long
+
+    :param end_absolute: Absolute end time in milliseconds, overrides the end parameter which is relative
+    :type end_absolute: long
 
     :return: Result queries.
     :rtype: dict


### PR DESCRIPTION
Support for start_absolute and end_absolute was added to the zmon worker as part
of PR https://github.com/zalando-zmon/zmon-worker/pull/237

Updating the documentation to include these parameters.

The check will still default to using start and end relative. Should start_absolute
or end_absolute be set they will override accordingly.

Example usage:

```python
def check():
    current_time = timestamp()
    current_time_millis = current_time * 1000
    start_of_day = current_time - (current_time % 86400)
    start_of_day_millis = start_of_day * 1000
    end_of_day = start_of_day + 86400
    end_of_day_millis = end_of_day * 1000

    max = kairosdb(oauth2=True).query('zmon.check.00000',
                                         tags={"key": ["count"]},
                                         aggregators=[{
                                             'name': 'max',
                                             'sampling': {
                                                 'value': 1,
                                                 'unit': 'days'
                                             }
                                         }],
                                         group_by=[{
                                             'name': 'tag',
                                             'tags': ['key','entity']
                                        }],
                                        start_absolute=start_of_day_millis,
                                        end_absolute=end_of_day_millis)
```

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>