### PR TITLE
Adds authentication section

### DIFF
--- a/docs/developer/zmon-cli.rst
+++ b/docs/developer/zmon-cli.rst
@@ -22,6 +22,15 @@ Configure your zmon cli by running ``configure``-
 
   zmon configure
 
+Authentication
+^^^^^^^^^^^^^^
+
+ZMON CLI tool must authenticate against zmon. Internally in uses zign to obtain access token, but you can override that behaviour by exporting a variable ZMON_TOKEN.
+
+.. code-block:: bash
+
+  export ZMON_TOKEN=myfancytoken
+
 If you are using github for authentication, have an unprivileged personal access token ready.
 
 Entities

--- a/docs/developer/zmon-cli.rst
+++ b/docs/developer/zmon-cli.rst
@@ -25,7 +25,7 @@ Configure your zmon cli by running ``configure``-
 Authentication
 ^^^^^^^^^^^^^^
 
-ZMON CLI tool must authenticate against zmon. Internally in uses zign to obtain access token, but you can override that behaviour by exporting a variable ZMON_TOKEN.
+ZMON CLI tool must authenticate against ZMON. Internally in uses zign to obtain access token, but you can override that behaviour by exporting a variable ZMON_TOKEN.
 
 .. code-block:: bash
 

--- a/docs/developer/zmon-cli.rst
+++ b/docs/developer/zmon-cli.rst
@@ -25,7 +25,7 @@ Configure your zmon cli by running ``configure``-
 Authentication
 ^^^^^^^^^^^^^^
 
-ZMON CLI tool must authenticate against ZMON. Internally in uses zign to obtain access token, but you can override that behaviour by exporting a variable ZMON_TOKEN.
+ZMON CLI tool must authenticate against ZMON. Internally it uses zign to obtain access token, but you can override that behaviour by exporting a variable ZMON_TOKEN.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Authentication section briefly explains how ZMON CLI obtains access tokens with either `zign` or `ZMON_TOKEN` environment variable.