### PR TITLE
include the new description parameter in notify_opsgenie documentation

### DIFF
--- a/docs/user/notifications/opsgenie.rst
+++ b/docs/user/notifications/opsgenie.rst
@@ -26,7 +26,7 @@ Notify `Opsgenie <https://www.opsgenie.com/>`_ of a new alert status. If alert i
     :type include_alert: bool
 
     :param description: An optional description. If present, this is inserted into the opsgenie alert description field.
-    :type message: str
+    :type description: str
 
 
     Example:

--- a/docs/user/notifications/opsgenie.rst
+++ b/docs/user/notifications/opsgenie.rst
@@ -4,7 +4,7 @@ Opsgenie
 Notify `Opsgenie <https://www.opsgenie.com/>`_ of a new alert status. If alert is **active**, then a new opsgenie alert will be created. If alert is **inactive** then the alert will be closed.
 
 
-.. py:function:: notify_opsgenie(message='', teams=None, per_entity=False, priority=None, include_alert=True, **kwargs)
+.. py:function:: notify_opsgenie(message='', teams=None, per_entity=False, priority=None, include_alert=True, description='', **kwargs)
 
     ::
 
@@ -24,6 +24,9 @@ Notify `Opsgenie <https://www.opsgenie.com/>`_ of a new alert status. If alert i
 
     :param include_alert: Include alert data in alert body ``details``. Default is ``True``.
     :type include_alert: bool
+
+    :param description: An optional description. If present, this is inserted into the opsgenie alert description field.
+    :type message: str
 
 
     Example:


### PR DESCRIPTION
This PR adds documentation for the new `description` parameter added to the `notify_opsgenie` function [here](https://github.com/zalando-zmon/zmon-worker/pull/279)