### PR TITLE
mention usage of unicode subject

### DIFF
--- a/docs/user/notifications/mail.rst
+++ b/docs/user/notifications/mail.rst
@@ -8,7 +8,10 @@ Send email notifications.
     Send email notification.
 
     :param subject: Email subject.
-    :type subject: str
+                    You must use a unicode string (e.g. `u'äöüß'`) if you have non-ASCII
+                    characters in there.
+                    If None, the alert name will be used.
+    :type subject: str or unicode or None
 
     :param cc: List of CC recipients.
     :type cc: list


### PR DESCRIPTION
When using unicode characters in a non-unicode string, currently you'll get an exception (visible in the log of your worker) and the email is just not sent. Prefixing the string with `u` seems to help. I think documenting this will avoid some more people making this mistake.

I didn't check yet whether this is valid reST/Sphinx syntax, please verify.